### PR TITLE
swift compiler crash fix

### DIFF
--- a/Sources/Leaf/Tag/Models/Extend.swift
+++ b/Sources/Leaf/Tag/Models/Extend.swift
@@ -35,7 +35,7 @@ extension Leaf {
                 return
             }
 
-            template.parameters.first?.constant.flatMap { importName in
+            if let importName = template.parameters.first?.constant {
                 if let exported = exports[importName] {
                     comps += exported.components.array
                 } else if let fallback = template.body {


### PR DESCRIPTION
Small syntax change that prevents the compiler from crashing in certain situations.