### PR TITLE
Add datetime support

### DIFF
--- a/Sources/Leaf/Node+Rendered.swift
+++ b/Sources/Leaf/Node+Rendered.swift
@@ -11,6 +11,8 @@ extension Node {
             return str.bytes
         case let .bytes(bytes):
             return bytes
+        case let .date(date):
+            return date.description.bytes 
         }
     }
 }

--- a/Sources/Leaf/Tag/Models/Equal.swift
+++ b/Sources/Leaf/Tag/Models/Equal.swift
@@ -54,5 +54,8 @@ fileprivate func fuzzyEquals(_ lhs: Node?, _ rhs: Node?) -> Bool {
         return true
     case let .string(string):
         return string == rhs.string
+    case let .date(date):
+        guard case let .date(rhs) = rhs else { return false }
+        return date == rhs
     }
 }


### PR DESCRIPTION
I am submitting a series of pull requests to add Date as a class in Node and datetime and timestamp support in Fluent. This allows for full support for time throughout Vapor.

Specifically, there are pull requests for Vapor, Fluent, Node, JSON, MySQL, Leaf, and FluentMySQL