### PR TITLE
Proposal: #if(string) to not render if string is blank

### DIFF
--- a/Resources/if-empty-string-test.leaf
+++ b/Resources/if-empty-string-test.leaf
@@ -1,0 +1,1 @@
+#if(name) { Hello, there! }

--- a/Sources/Leaf/Tag/Models/If.swift
+++ b/Sources/Leaf/Tag/Models/If.swift
@@ -21,8 +21,11 @@ public final class If: Tag {
         arguments: [Argument],
         value: Node?) -> Bool {
         guard let value = arguments.first?.value else { return false }
-        // Existence of bool, evaluate bool. Otherwise, not-nil returns true.
-        guard let bool = value.bool else { return true }
-        return bool
+        // Existence of bool, evaluate bool.
+        if let bool = value.bool { return bool }
+        // Empty string value returns false.
+        if value.string == "" { return false }
+        // Otherwise, not-nil returns true.
+        return true
     }
 }

--- a/Tests/LeafTests/IfTests.swift
+++ b/Tests/LeafTests/IfTests.swift
@@ -9,6 +9,7 @@ class IfTests: XCTestCase {
         ("testBasicIfElse", testBasicIfElse),
         ("testNestedIfElse", testNestedIfElse),
         ("testIfThrow", testIfThrow),
+        ("testIfEmptyString", testIfEmptyString),
     ]
 
     func testBasicIf() throws {
@@ -77,5 +78,23 @@ class IfTests: XCTestCase {
             _ = try stem.render(leaf, with: context)
             XCTFail("should throw")
         } catch If.Error.expectedSingleArgument {}
+    }
+
+    func testIfEmptyString() throws {
+        let template = try stem.spawnLeaf(named: "if-empty-string-test")
+        do {
+            let context = try Node(node: ["name": "name"])
+            let loadable = Context(context)
+            let rendered = try stem.render(template, with: loadable).string
+            let expectation = "Hello, there!"
+            XCTAssert(rendered == expectation, "have: \(rendered), want: \(expectation)")
+        }
+        do {
+            let context = try Node(node: ["name": ""])
+            let loadable = Context(context)
+            let rendered = try stem.render(template, with: loadable).string
+            let expectation = ""
+            XCTAssert(rendered == expectation, "have: \(rendered), want: \(expectation)")
+        }
     }
 }


### PR DESCRIPTION
This is something of a matter of opinion.

Currently, if a Node represents a blank string, using that node as the argument to `#if` will cause the block to render. I believe that `#if` should consider a blank string to be equivalent to `false`, in this case, and therefore not render.

In Polymorphic a `bool` has three states: true, false or nil, and `""` becomes nil, which makes sense. In this tag, `""` is considered not-nil and so returns true, rendering the block.

This patch and test causes `#if("")` to not render its block.

The alternative, and it's also a valid one, is to force the user of the `#if` tag to convert empty strings to false or nil before rendering.