### PR TITLE
Workaround for the CRLF+quote crash on Linux

### DIFF
--- a/Sources/Leaf/HTMLEscape.swift
+++ b/Sources/Leaf/HTMLEscape.swift
@@ -3,8 +3,8 @@ import Foundation
 extension String {
     func htmlEscaped() -> String {
         return replacingOccurrences(of: "&", with: "&amp;")
-            .replacingOccurrences(of: "\"", with: "&quot;")
-            .replacingOccurrences(of: "'", with: "&#39;")
+            .replacingOccurrences(of: "\"", with: "&quot;", options: [.regularExpression])
+            .replacingOccurrences(of: "'", with: "&#39;", options: [.regularExpression])
             .replacingOccurrences(of: "<", with: "&lt;")
             .replacingOccurrences(of: ">", with: "&gt;")
     }

--- a/Tests/LeafTests/HTMLEscapeTests.swift
+++ b/Tests/LeafTests/HTMLEscapeTests.swift
@@ -1,0 +1,24 @@
+import Foundation
+import XCTest
+@testable import Leaf
+
+class HTMLEscapeTests: XCTestCase {
+    static let allTests = [
+        ("testHTMLEscape", testHTMLEscape),
+        ("testHTMLEscapeCRLFQuotes", testHTMLEscapeCRLFQuotes),
+    ]
+
+    func testHTMLEscape() throws {
+        let input = "&\"'<>"
+        let expected = "&amp;&quot;&#39;&lt;&gt;"
+        
+        XCTAssertEqual(input.htmlEscaped(), expected)
+    }
+    
+    func testHTMLEscapeCRLFQuotes() throws {
+        let input = "\r\n\""
+        let expected = "\r\n&quot;"
+        
+        XCTAssertEqual(input.htmlEscaped(), expected)
+    }
+}

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -9,6 +9,7 @@ XCTMain([
      testCase(FileLoadTests.allTests),
      testCase(IfTests.allTests),
      testCase(IndexTests.allTests),
+     testCase(HTMLEscapeTests.allTests),
      testCase(LinkTests.allTests),
      testCase(LoopTests.allTests),
      testCase(NodeRenderTests.allTests),


### PR DESCRIPTION
The crash seems to be caused by a bug in the open source Foundation's `replacingOccurrences` method, which is already known as SR-3448 and its fix was just merged yesterday.

This PR add some tests and resolves #41 with the regular expression workaround found under their ticket. This fix was tested with Swift 3.0.2 in Docker.