### PR TITLE
workdir

### DIFF
--- a/Sources/Leaf/NSData+File.swift
+++ b/Sources/Leaf/NSData+File.swift
@@ -1,7 +1,0 @@
-import Foundation
-
-extension Sequence where Iterator.Element == Byte {
-    internal static func load(path: String) throws -> Bytes {
-        return try DataFile().load(path: path)
-    }
-}

--- a/Sources/Leaf/Stem+Spawn.swift
+++ b/Sources/Leaf/Stem+Spawn.swift
@@ -13,14 +13,6 @@ extension Stem {
         }
         return leaf
     }
-
-    public func spawnLeaf(named name: String) throws -> Leaf {
-        var name = name
-        if name.hasPrefix("/") {
-            name = String(name.characters.dropFirst())
-        }
-        return try spawnLeaf(at: workingDirectory + name)
-    }
     
     public func spawnLeaf(at path: String) throws -> Leaf {
         if let existing = cache?[path] {
@@ -31,7 +23,7 @@ extension Stem {
         
         // non-leaf document. rendered as pure bytes
         if path.components(separatedBy: "/").last?.contains(".") == true, !path.hasSuffix(".leaf") {
-            let bytes = try Bytes.load(path: path)
+            let bytes = try file.load(path: path)
             let component = Leaf.Component.raw(bytes)
             leaf = Leaf(raw: bytes.makeString(), components: [component])
         } else {
@@ -39,7 +31,7 @@ extension Stem {
             var path = path
             path = path.finished(with: SUFFIX)
             
-            let raw = try Bytes.load(path: path)
+            let raw = try file.load(path: path)
             leaf = try spawnLeaf(raw: raw)
         }
         

--- a/Sources/Leaf/Stem+Spawn.swift
+++ b/Sources/Leaf/Stem+Spawn.swift
@@ -23,7 +23,7 @@ extension Stem {
         
         // non-leaf document. rendered as pure bytes
         if path.components(separatedBy: "/").last?.contains(".") == true, !path.hasSuffix(".leaf") {
-            let bytes = try file.load(path: path)
+            let bytes = try file.read(at: path)
             let component = Leaf.Component.raw(bytes)
             leaf = Leaf(raw: bytes.makeString(), components: [component])
         } else {
@@ -31,7 +31,7 @@ extension Stem {
             var path = path
             path = path.finished(with: SUFFIX)
             
-            let raw = try file.load(path: path)
+            let raw = try file.read(at: path)
             leaf = try spawnLeaf(raw: raw)
         }
         

--- a/Sources/Leaf/Stem.swift
+++ b/Sources/Leaf/Stem.swift
@@ -1,10 +1,13 @@
+import Core
+
 public final class Stem {
-    public let workingDirectory: String
+    // public let workingDirectory: String
+    public let file: FileProtocol
     public var cache: [String: Leaf]?
     public fileprivate(set) var tags: [String: Tag] = defaultTags
 
-    public init(workingDirectory: String, cache: [String: Leaf]? = [:]) {
-        self.workingDirectory = workingDirectory.finished(with: "/")
+    public init(_ file: FileProtocol, cache: [String: Leaf]? = [:]) {
+        self.file = file
         self.cache = cache
     }
 }

--- a/Sources/Leaf/Stem.swift
+++ b/Sources/Leaf/Stem.swift
@@ -1,7 +1,6 @@
 import Core
 
 public final class Stem {
-    // public let workingDirectory: String
     public let file: FileProtocol
     public var cache: [String: Leaf]?
     public fileprivate(set) var tags: [String: Tag] = defaultTags

--- a/Sources/Leaf/Tag/Models/Embed.swift
+++ b/Sources/Leaf/Tag/Models/Embed.swift
@@ -15,7 +15,7 @@ public final class Embed: Tag {
                 throw Error.expectedSingleConstant(have: tagTemplate.parameters)
             }
 
-        let body = try stem.spawnLeaf(named: name)
+        let body = try stem.spawnLeaf(at: name)
         return TagTemplate(
             name: tagTemplate.name,
             parameters: [], // no longer need parameters

--- a/Sources/Leaf/Tag/Models/Extend.swift
+++ b/Sources/Leaf/Tag/Models/Extend.swift
@@ -56,7 +56,7 @@ extension Stem {
             template.name == "extend",
             let name = template.parameters.first?.constant
             else { return leaf }
-        return try spawnLeaf(named: name)
+        return try spawnLeaf(at: name)
     }
 }
 

--- a/Tests/LeafTests/EmbedTests.swift
+++ b/Tests/LeafTests/EmbedTests.swift
@@ -9,7 +9,7 @@ class EmbedTests: XCTestCase {
     ]
 
     func testBasicEmbed() throws {
-        let template = try stem.spawnLeaf(named: "/embed-base")
+        let template = try stem.spawnLeaf(at: "embed-base")
         let context = Context(["name": "World"])
         let rendered = try stem.render(template, with: context).makeString()
         let expectation = "Leaf embedded: Hello, World!"

--- a/Tests/LeafTests/FileLoadTests.swift
+++ b/Tests/LeafTests/FileLoadTests.swift
@@ -8,7 +8,7 @@ class FileLoadTests: XCTestCase {
     ]
 
     func testLoadRawBytes() throws {
-        let leaf = try stem.spawnLeaf(named: "random-file.any")
+        let leaf = try stem.spawnLeaf(at: "random-file.any")
         XCTAssert(Array(leaf.components).count == 1)
 
         let rendered = try stem.render(leaf, with: Context([])).makeString()
@@ -17,6 +17,6 @@ class FileLoadTests: XCTestCase {
         XCTAssertEqual(rendered, expectation)
 
         // test cache
-        _ = try stem.spawnLeaf(named: "random-file.any")
+        _ = try stem.spawnLeaf(at: "random-file.any")
     }
 }

--- a/Tests/LeafTests/IfTests.swift
+++ b/Tests/LeafTests/IfTests.swift
@@ -13,7 +13,7 @@ class IfTests: XCTestCase {
     ]
 
     func testBasicIf() throws {
-        let template = try stem.spawnLeaf(named: "basic-if-test")
+        let template = try stem.spawnLeaf(at: "basic-if-test")
 
         let context = try Node(node: ["say-hello": true])
         let loadable = Context(context)
@@ -23,7 +23,7 @@ class IfTests: XCTestCase {
     }
 
     func testBasicIfFail() throws {
-        let template = try stem.spawnLeaf(named: "basic-if-test")
+        let template = try stem.spawnLeaf(at: "basic-if-test")
 
         let context = try Node(node: ["say-hello": false])
         let loadable = Context(context)
@@ -33,7 +33,7 @@ class IfTests: XCTestCase {
     }
 
     func testBasicIfElse() throws {
-        let template = try stem.spawnLeaf(named: "basic-if-else")
+        let template = try stem.spawnLeaf(at: "basic-if-else")
 
         let helloContext = try Node(node: [
             "entering": true,
@@ -55,7 +55,7 @@ class IfTests: XCTestCase {
     }
 
     func testNestedIfElse() throws {
-        let template = try stem.spawnLeaf(named: "nested-if-else")
+        let template = try stem.spawnLeaf(at: "nested-if-else")
         let expectations: [(input: Node, expectation: String)] = [
             (input: ["a": true], expectation: "Got a."),
             (input: ["b": true], expectation: "Got b."),
@@ -81,7 +81,7 @@ class IfTests: XCTestCase {
     }
 
     func testIfEmptyString() throws {
-        let template = try stem.spawnLeaf(named: "if-empty-string-test")
+        let template = try stem.spawnLeaf(at: "if-empty-string-test")
         do {
             let context = try Node(node: ["name": "name"])
             let loadable = Context(context)

--- a/Tests/LeafTests/LayoutTests.swift
+++ b/Tests/LeafTests/LayoutTests.swift
@@ -11,7 +11,7 @@ class LayoutTests: XCTestCase {
     ]
 
     func testBasicLayout() throws {
-        let leaf = try stem.spawnLeaf(named: "basic-extension")
+        let leaf = try stem.spawnLeaf(at: "basic-extension")
         let rendered = try stem.render(leaf, with: Context(["name": "World"])).makeString()
         let expectation = "Aloha, World!"
         XCTAssertEqual(rendered, expectation)

--- a/Tests/LeafTests/LoopTests.swift
+++ b/Tests/LeafTests/LoopTests.swift
@@ -14,7 +14,7 @@ class LoopTests: XCTestCase {
     ]
 
     func testBasicLoop() throws {
-        let template = try stem.spawnLeaf(named: "basic-loop")
+        let template = try stem.spawnLeaf(at: "basic-loop")
 
         let context = try Node(node: [
             "friends": [
@@ -48,7 +48,7 @@ class LoopTests: XCTestCase {
             ]
             ])
 
-        let template = try stem.spawnLeaf(named: "complex-loop")
+        let template = try stem.spawnLeaf(at: "complex-loop")
         let loadable = Context(context)
         let rendered = try stem.render(template, with: loadable).makeString()
         let expectation = "<li><b>Venus</b>: 12345</li>\n<li><b>Pluto</b>: 888</li>\n<li><b>Mercury</b>: 9000</li>"

--- a/Tests/LeafTests/RawTests.swift
+++ b/Tests/LeafTests/RawTests.swift
@@ -8,7 +8,7 @@ class RawTests: XCTestCase {
     ]
 
     func testRaw() throws {
-        let raw = try stem.spawnLeaf(named: "raw")
+        let raw = try stem.spawnLeaf(at: "raw")
         let rendered = try stem.render(raw, with: Context([:])).makeString()
         let expectation = "Everything stays ##@$&"
         XCTAssertEqual(rendered, expectation)

--- a/Tests/LeafTests/RenderTests.swift
+++ b/Tests/LeafTests/RenderTests.swift
@@ -24,7 +24,7 @@ class RenderTests: XCTestCase {
     }
 
     func testBasicRender() throws {
-        let template = try stem.spawnLeaf(named: "basic-render")
+        let template = try stem.spawnLeaf(at: "basic-render")
         let contexts = ["a", "ab9###", "ajcm301kc,s--11111", "World", "👾"]
 
         try contexts.forEach { context in
@@ -36,7 +36,7 @@ class RenderTests: XCTestCase {
     }
 
     func testNestedBodyRender() throws {
-        let template = try stem.spawnLeaf(named: "nested-body")
+        let template = try stem.spawnLeaf(at: "nested-body")
 
         let contextTests: [Node] = [
             try .init(node: ["best-friend": ["name": "World"]]),

--- a/Tests/LeafTests/SharedModels.swift
+++ b/Tests/LeafTests/SharedModels.swift
@@ -10,7 +10,8 @@
     private let workDir = "./Resources/"
 #endif
 
-let stem = Stem(workingDirectory: workDir)
+let file = DataFile(workDir: workDir)
+let stem = Stem(file)
 
 class Test: Tag {
     let name: String


### PR DESCRIPTION
- `Stem` gets created with a `FileProtocol` instead of a working directory
- File protocol is responsible for resolving relative filenames
- This allows us to implement custom file protocols that can lookup in multiple places (such as providers) for relative file paths.

Relies on https://github.com/vapor/core/pull/44