### PR TITLE
Fix/fix 52 ‘#export()'depends on ‘{‘ location

### DIFF
--- a/Resources/no-body-whitespace.leaf
+++ b/Resources/no-body-whitespace.leaf
@@ -1,0 +1,3 @@
+#extend("basic-extendable")
+
+#export("greeting"){ Aloha }

--- a/Resources/variable-body-whitespace.leaf
+++ b/Resources/variable-body-whitespace.leaf
@@ -1,0 +1,9 @@
+#extend("basic-extendable")
+
+#export("greeting")
+
+
+
+      { Aloha }
+
+

--- a/Tests/LeafTests/BodyWhitespaceTests.swift
+++ b/Tests/LeafTests/BodyWhitespaceTests.swift
@@ -1,0 +1,26 @@
+import Foundation
+import XCTest
+@testable import Leaf
+
+class BodyWhitespaceTests: XCTestCase {
+    
+    static let allTests = [
+        ("testAdditionalWhitespace", testAdditionalWhitespace),
+        ("testNoWhitespace", testNoWhitespace)
+    ]
+    
+    func testAdditionalWhitespace() throws {
+        let leaf = try stem.spawnLeaf(at: "variable-body-whitespace")
+        let rendered = try stem.render(leaf, with: Context(["name": "World"])).makeString()
+        let expectation = "Aloha, World!"
+        XCTAssertEqual(rendered, expectation)
+    }
+    
+    func testNoWhitespace() throws {
+        let leaf = try stem.spawnLeaf(at: "no-body-whitespace")
+        let rendered = try stem.render(leaf, with: Context(["name": "World"])).makeString()
+        let expectation = "Aloha, World!"
+        XCTAssertEqual(rendered, expectation)
+    }
+
+}

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -21,4 +21,5 @@ XCTMain([
      testCase(VariableTests.allTests),
      testCase(LayoutTests.allTests),
      testCase(RawTests.allTests),
+     testCase(BodyWhitespaceTests.allTests)
 ])


### PR DESCRIPTION
All tests passing. 

Please let me know any feedback or if I've totally missed the mark on this one. Thanks.

#52 