### PR TITLE
Updated dependencies and prepared for RC

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,16 +8,16 @@ let package = Package(
     ],
     dependencies: [
         // Swift Promises, Futures, and Streams.
-        .package(url: "https://github.com/vapor/async.git", "1.0.0-beta.1"..<"1.0.0-beta.2"),
+        .package(url: "https://github.com/vapor/async.git", from: "1.0.0-rc"),
 
         // Core extensions, type-aliases, and functions that facilitate common tasks.
-        .package(url: "https://github.com/vapor/core.git", "3.0.0-beta.1"..<"3.0.0-beta.2"),
+        .package(url: "https://github.com/vapor/core.git", from: "3.0.0-rc"),
 
         // Service container and configuration system.
-        .package(url: "https://github.com/vapor/service.git", "1.0.0-beta.1"..<"1.0.0-beta.2"),
+        .package(url: "https://github.com/vapor/service.git", from: "1.0.0-rc"),
 
         // Easy-to-use foundation for building powerful templating languages in Swift.
-        .package(url: "https://github.com/vapor/template-kit.git", "1.0.0-beta.1"..<"1.0.0-beta.2"),
+        .package(url: "https://github.com/vapor/template-kit.git", from: "1.0.0-rc"),
     ],
     targets: [
         .target(name: "Leaf", dependencies: ["Async", "Bits", "CodableKit", "COperatingSystem", "Service", "TemplateKit"]),


### PR DESCRIPTION
It's theoretically ready for a merge as far as I can tell and projects that depend only on Vapor and Leaf can safely use `rc.1` version of both (at least my short testing earlier today showed no obvious compatibility issues).

Realistically though, it may often result in an unsolvable dependency tree as Fluent doesn't have release candidate yet. So maybe waiting for tagging Fluent would make more sense? ¯\\\_(ツ)\_/¯