### PR TITLE
add TemplateData .date test

### DIFF
--- a/Tests/LeafTests/TemplateDataEncoderTests.swift
+++ b/Tests/LeafTests/TemplateDataEncoderTests.swift
@@ -15,6 +15,18 @@ class TemplateDataEncoderTests: XCTestCase {
         try XCTAssertEqual(TemplateDataEncoder().testEncode(data), .double(data))
     }
 
+    func testDate() {
+        let interval: Double = -1000000
+        let date: Date = Date(timeIntervalSince1970: interval)
+        if let data: TemplateData = try? date.convertToTemplateData() {
+            XCTAssertEqual(data.date, date)
+            // note: test purposes only, interval cannot be recovered if not actually a Double(Int)
+            XCTAssertEqual(data.date?.timeIntervalSince1970, interval)
+        } else {
+            XCTFail()
+        }
+    }
+
     func testDictionary() {
         let data: [String: String] = ["string": "hello", "foo": "3.14"]
         try XCTAssertEqual(TemplateDataEncoder().testEncode(data), .dictionary([


### PR DESCRIPTION
Adds test to parallel the one in https://github.com/vapor/template-kit/pull/18 (which needs to be merged first due to dependency).