### PR TITLE
Allow modification of LeafTagConfig

### DIFF
--- a/Sources/Leaf/Service/LeafConfig.swift
+++ b/Sources/Leaf/Service/LeafConfig.swift
@@ -17,10 +17,14 @@ public struct LeafConfig: Service {
     }
 }
 
-public struct LeafTagConfig: Service {
+public class LeafTagConfig: Service {
     var storage: [String: TagRenderer]
 
-    public mutating func use(_ tag: TagRenderer, as name: String) {
+    init(storage: [String: TagRenderer]) {
+        self.storage = storage
+    }
+
+    public func use(_ tag: TagRenderer, as name: String) {
         self.storage[name] = tag
     }
 

--- a/Sources/Leaf/Service/LeafProvider.swift
+++ b/Sources/Leaf/Service/LeafProvider.swift
@@ -27,9 +27,7 @@ public final class LeafProvider: Provider {
             )
         }
 
-        services.register { container -> LeafTagConfig in
-            return LeafTagConfig.default()
-        }
+        services.register(LeafTagConfig.default())
     }
 
     /// See Service.Provider.boot


### PR DESCRIPTION
### Introduction

This PR is meant to open a discussion about how to register multiple sets of leaf tags from different sources. 

### Motivation

It is currently not possible for providers to register their own leaf tags because:
- The way LeafTagConfig is registered, results in a fresh copy each time it is created.
- LeafTagConfig is a struct, so local mutations have no effect.

Developers have to know about all sources of leaf tags and register them under the "right" name. This can get messy when providers register other providers and when packages come with their own templates that assume tags being registered under specific names.

### Proposed solution

- make LeafTagConfig a class
- register an instance instead of using a factory

This allows providers to add code like the following in the `didBoot` method:

```swift
let tags: LeafTagConfig = try container.make()
tags.use(MyTag(), as: "mytag")
```

### Alternatives

Create something like a `TagStoreProvider` which registers a `TagStore` service which providers can register their tags on. The developer would then have to do something like:

```swift
services.register { container -> LeafTagConfig in
    let tagStore = container.make(TagStore.self)
    let tagConfig = LeafTagConfig.default()
    for (name, tag) in tagStore.tags {
        tagConfig.use(tag, as: name)
    }
    return tagConfig
}
```