### PR TITLE
Body detection

### DIFF
--- a/Sources/Leaf/Parser/LeafParser.swift
+++ b/Sources/Leaf/Parser/LeafParser.swift
@@ -426,12 +426,11 @@ extension TemplateByteScanner {
             if let next = peek(), next == .leftCurlyBracket {
                 bodies += 1
                 //Append
-                let lastast = syntax
-                switch lastast.type {
+                switch syntax.type {
                 case .raw(let raw):
                     ast[ast.count - 1] = TemplateSyntax(
                         type: .raw(TemplateRaw(data: raw.data + Data(bytes: [next]))),
-                        source: lastast.source
+                        source: syntax.source
                     )
                     try requirePop()
                 default:
@@ -444,12 +443,11 @@ extension TemplateByteScanner {
                     break
                 } else {
                     //Append
-                    let lastast = syntax
-                    switch lastast.type {
+                    switch syntax.type {
                     case .raw(let raw):
                         ast[ast.count - 1] = TemplateSyntax(
                             type: .raw(TemplateRaw(data: raw.data + Data(bytes: [next]))),
-                            source: lastast.source
+                            source: syntax.source
                         )
                     default:
                         throw TemplateKitError(identifier: "extractBody", reason: "Unexpected rightCurlyBracket", source: makeSource(using: makeSourceStart()))

--- a/Sources/Leaf/Parser/LeafParser.swift
+++ b/Sources/Leaf/Parser/LeafParser.swift
@@ -327,17 +327,12 @@ extension TemplateByteScanner {
     private func extractBody() throws -> [TemplateSyntax] {
         try expect(.leftCurlyBracket)
 
-        /// create empty base syntax element, to simplify logic
-        let base = TemplateSyntax(
-            type: .raw(TemplateRaw(data: .empty)),
-            source: makeSource(using: makeSourceStart())
-        )
-        var ast: [TemplateSyntax] = [base]
+        var ast: [TemplateSyntax] = []
 
         var bodies = 1
 
         // ast.append(TemplateSyntax(type: .raw(.empty), source: TemplateSource(line: 0, column: 0, range: 0..<1)))
-        while let syntax = try extractSyntax(untilUnescaped: [.rightCurlyBracket, .leftCurlyBracket], indent: indent, previous: &ast[ast.count - 1]) {
+        while let syntax = try extractSyntax(untilUnescaped: [.rightCurlyBracket, .leftCurlyBracket]) {
             ast.append(syntax)
             if let next = peek(), next == .leftCurlyBracket {
                 bodies += 1


### PR DESCRIPTION
This pull tries to identify the closing brace of a body without needing it's contents to be escaped by counting through them. After whipping up some test files with a mix of escaped/unescaped braces, and what would work right now I haven't run into problems so this would be non breaking with existing syntax, preserving that behaviour. Of course, I probably haven't thought of every scenario though I'm happy to adapt this patch if required.

I've been using this for some time and am yet to hit a problem. The idea of escaping chunks of javascript or CSS braces inline in leaf files isn't particularly attractive to me. This is a bit of a hack and could probably be done better with a larger rewrite of the parser. While I haven't properly performance tested it this though, I haven't noticed a problem on a low traffic site with some quite large pages (1500 line leaf templates for example).

Perfectly understand if this gets rejected, open to input.

Cheers.