### PR TITLE
update dependencies for 3.0.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,13 +8,13 @@ let package = Package(
     ],
     dependencies: [
         // 🌎 Utility package containing tools for byte manipulation, Codable, OS APIs, and debugging.
-        .package(url: "https://github.com/vapor/core.git", from: "3.0.0-rc.2"),
+        .package(url: "https://github.com/vapor/core.git", from: "3.4.1"),
 
         // 📦 Dependency injection / inversion of control framework.
-        .package(url: "https://github.com/vapor/service.git", from: "1.0.0-rc.2"),
+        .package(url: "https://github.com/vapor/service.git", from: "1.0.0"),
 
         // 📄 Easy-to-use foundation for building powerful templating languages in Swift.
-        .package(url: "https://github.com/vapor/template-kit.git", from: "1.0.0-rc.2"),
+        .package(url: "https://github.com/vapor/template-kit.git", from: "1.1.0"),
     ],
     targets: [
         .target(name: "Leaf", dependencies: ["Async", "Bits", "COperatingSystem", "Service", "TemplateKit"]),


### PR DESCRIPTION
Updated Leaf 3.0.0 dependencies to as of current date release versions – `template-kit 1.1.0` being the critical one.