### PR TITLE
Fix parsing inline comments

### DIFF
--- a/Sources/Leaf/Parser/LeafParser.swift
+++ b/Sources/Leaf/Parser/LeafParser.swift
@@ -195,13 +195,12 @@ extension TemplateByteScanner {
         // Extract tag body.
         let body: [TemplateSyntax]?
         if name == "//" {
-            var onlyCommentLine: Bool
-            onlyCommentLine = peek(by: -4) == .newLine
+            let isEntirelyCommentLine: Bool = (peek(by: -4) == .newLine)
 
             let s = makeSourceStart()
             let bytes = try extractBytes(untilUnescaped: [.newLine])
 
-            if onlyCommentLine {
+            if isEntirelyCommentLine {
                 try requirePop()
             }
 

--- a/Sources/Leaf/Parser/LeafParser.swift
+++ b/Sources/Leaf/Parser/LeafParser.swift
@@ -195,14 +195,21 @@ extension TemplateByteScanner {
         // Extract tag body.
         let body: [TemplateSyntax]?
         if name == "//" {
+            var onlyCommentLine: Bool
+            onlyCommentLine = peek(by: -4) == .newLine
+
             let s = makeSourceStart()
             let bytes = try extractBytes(untilUnescaped: [.newLine])
-            // pop the newline
-            try requirePop()
+
+            if onlyCommentLine {
+                try requirePop()
+            }
+
             body = [TemplateSyntax(
                 type: .raw(TemplateRaw(data: bytes)),
                 source: makeSource(using: s)
             )]
+
         } else if name == "/*" {
             let s = makeSourceStart()
             var i = 0

--- a/Tests/LeafTests/LeafTests.swift
+++ b/Tests/LeafTests/LeafTests.swift
@@ -433,6 +433,46 @@ class LeafTests: XCTestCase {
         }
     }
 
+    // https://github.com/vapor/leaf/issues/127
+    func testGH127Inline() throws {
+        do {
+            let template = """
+            <html>
+            <head>
+            <title></title>#// Translate all copy!!!!!
+            <style>
+            """
+            let expected = """
+            <html>
+            <head>
+            <title></title>
+            <style>
+            """
+            let data = try TemplateDataEncoder().testEncode(["a": "a"])
+            try XCTAssertEqual(renderer.testRender(template, data), expected)
+        }
+    }
+
+    func testGH127SingleLine() throws {
+        do {
+            let template = """
+            <html>
+            <head>
+            <title></title>
+            #// Translate all copy!!!!!
+            <style>
+            """
+            let expected = """
+            <html>
+            <head>
+            <title></title>
+            <style>
+            """
+            let data = try TemplateDataEncoder().testEncode(["a": "a"])
+            try XCTAssertEqual(renderer.testRender(template, data), expected)
+        }
+    }
+
     static var allTests = [
         ("testPrint", testPrint),
         ("testConstant", testConstant),

--- a/Tests/LeafTests/LeafTests.swift
+++ b/Tests/LeafTests/LeafTests.swift
@@ -504,6 +504,8 @@ class LeafTests: XCTestCase {
         ("testGH99", testGH99),
         ("testGH101", testGH101),
         ("testGH105", testGH105),
+        ("testGH127Inline", testGH127Inline),
+        ("testGH127SingleLine", testGH127SingleLine)
     ]
 }
 


### PR DESCRIPTION
Fixes bug: #127

Parsing in-line comment should not join following line.

* Only-comment lines should be removed from output
* End-of-line comments should not remove following line break