### PR TITLE
Swift 5 Updates

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.0
+// swift-tools-version:4.2
 import PackageDescription
 
 let package = Package(

--- a/Package@swift-5.swift
+++ b/Package@swift-5.swift
@@ -1,0 +1,24 @@
+// swift-tools-version:5.0
+import PackageDescription
+
+let package = Package(
+    name: "Leaf",
+    products: [
+        .library(name: "Leaf", targets: ["Leaf"]),
+    ],
+    dependencies: [
+        // 🌎 Utility package containing tools for byte manipulation, Codable, OS APIs, and debugging.
+        .package(url: "https://github.com/vapor/core.git", from: "3.8.1"),
+
+        // 📦 Dependency injection / inversion of control framework.
+        .package(url: "https://github.com/vapor/service.git", from: "1.0.2"),
+
+        // 📄 Easy-to-use foundation for building powerful templating languages in Swift.
+        .package(url: "https://github.com/vapor/template-kit.git", from: "1.1.2"),
+    ],
+    targets: [
+        .target(name: "Leaf", dependencies: ["Async", "Bits", "COperatingSystem", "Service", "TemplateKit"]),
+        .testTarget(name: "LeafTests", dependencies: ["Leaf"]),
+    ],
+    swiftLanguageVersions: [.v4_2, .v5]
+)

--- a/Sources/Leaf/Parser/LeafParser.swift
+++ b/Sources/Leaf/Parser/LeafParser.swift
@@ -39,7 +39,7 @@ extension TemplateByteScanner {
             } else {
                 let byte = try requirePop()
                 let start = makeSourceStart()
-                let bytes = try Data(bytes: [byte]) + extractRaw(untilUnescaped: signalBytes)
+                let bytes = try Data([byte]) + extractRaw(untilUnescaped: signalBytes)
                 let source = makeSource(using: start)
                 syntax = TemplateSyntax(
                     type: .raw(TemplateRaw(data: bytes)),
@@ -123,7 +123,7 @@ extension TemplateByteScanner {
         // Verify tag names containg / or * are comment tag names.
         if id.contains(where: { $0 == .forwardSlash || $0 == .asterisk }) {
             switch id {
-            case Data(bytes: [.forwardSlash, .forwardSlash]), Data(bytes: [.forwardSlash, .asterisk]):
+            case Data([.forwardSlash, .forwardSlash]), Data([.forwardSlash, .asterisk]):
                 break
             default:
                 throw TemplateKitError(identifier: "parse", reason: "Invalid tag name", source: makeSource(using: start))

--- a/circle.yml
+++ b/circle.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   macos:
     macos:
-      xcode: "9.0"
+      xcode: "10.2"
     steps:
       - checkout
       - run: swift build
@@ -11,7 +11,7 @@ jobs:
 
   linux:
     docker:
-      - image: codevapor/swift:4.1
+      - image: codevapor/swift:5.0
     steps:
       - checkout
       - run: swift build


### PR DESCRIPTION
Updates to support Swift 5:
* A Package.swift file
* Updated warnings that resulted from the language bump

The `Data` initializers that were changed mean that the minimum Swift version supported is 4.2 now, and I updated the main Package.swift file to reflect that as well.