### PR TITLE
Beta 3 Update

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,14 +4,14 @@ import PackageDescription
 let package = Package(
     name: "leaf",
     platforms: [
-       .macOS(.v10_14)
+       .macOS(.v10_15)
     ],
     products: [
         .library(name: "Leaf", targets: ["Leaf"]),
     ],
     dependencies: [
         .package(url: "https://github.com/vapor/leaf-kit.git", from: "1.0.0-beta.2"),
-        .package(url: "https://github.com/vapor/vapor.git", from: "4.0.0-beta.2"),
+        .package(url: "https://github.com/vapor/vapor.git", from: "4.0.0-beta.4"),
     ],
     targets: [
         .target(name: "Leaf", dependencies: ["LeafKit", "Vapor"]),


### PR DESCRIPTION
- Update to match new Vapor requirements for OS
- Require current Vapor beta version
- Leaf's major beta version has been bumped due to the new OS requirement (a breaking change), even though there are no changes to Leaf itself