### PR TITLE
Make app.leaf.cache settable

### DIFF
--- a/Sources/Leaf/LeafProvider.swift
+++ b/Sources/Leaf/LeafProvider.swift
@@ -30,7 +30,12 @@ extension Application {
         }
 
         public var cache: LeafCache {
-            self.storage.cache
+            get {
+                self.storage.cache
+            }
+            nonmutating set {
+                self.storage.cache = newValue
+            }
         }
 
         var storage: Storage {

--- a/Tests/LeafTests/LeafTests.swift
+++ b/Tests/LeafTests/LeafTests.swift
@@ -7,6 +7,7 @@ class LeafTests: XCTestCase {
         defer { app.shutdown() }
 
         app.views.use(.leaf)
+        app.leaf.cache.isEnabled = false
 
         app.get("test-file") { req in
             req.view.render(#file, ["foo": "bar"])


### PR DESCRIPTION
LeafCache is now settable (#155, fixes #154). 

```swift
app.leaf.cache.isEnabled = false
```
