### PR TITLE
File Sandboxing, Directory Limiting, and Multiple Template Sources

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "Leaf", targets: ["Leaf"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/tdotclare/leaf-kit.git", .revision("46be09e50cae28a03151acfcbb10972dd7e8d834")),
+        .package(url: "https://github.com/vapor/leaf-kit.git", from: "1.0.0-rc.1.11"),
         .package(url: "https://github.com/vapor/vapor.git", from: "4.0.0"),
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "Leaf", targets: ["Leaf"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/tdotclare/leaf-kit.git", .revision("bfcd150e0f60e6a68caf23152617109a04d85dcd")),
+        .package(url: "https://github.com/tdotclare/leaf-kit.git", .revision("46be09e50cae28a03151acfcbb10972dd7e8d834")),
         .package(url: "https://github.com/vapor/vapor.git", from: "4.0.0"),
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "Leaf", targets: ["Leaf"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/tdotclare/leaf-kit.git", .branch("Sandbox")),
+        .package(url: "https://github.com/tdotclare/leaf-kit.git", .revision("bfcd150e0f60e6a68caf23152617109a04d85dcd")),
         .package(url: "https://github.com/vapor/vapor.git", from: "4.0.0"),
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -10,8 +10,8 @@ let package = Package(
         .library(name: "Leaf", targets: ["Leaf"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/vapor/leaf-kit.git", from: "1.0.0-rc.1.2"),
-        .package(url: "https://github.com/vapor/vapor.git", from: "4.0.0-rc.1"),
+        .package(url: "https://github.com/tdotclare/leaf-kit.git", .branch("Sandbox")),
+        .package(url: "https://github.com/vapor/vapor.git", from: "4.0.0"),
     ],
     targets: [
         .target(name: "Leaf", dependencies: [

--- a/Sources/Leaf/Application+Leaf.swift
+++ b/Sources/Leaf/Application+Leaf.swift
@@ -51,9 +51,12 @@ extension Application {
             }
         }
 
-        public var files: LeafFiles {
+        public var files: LeafSource {
             get {
-                self.storage.files ?? NIOLeafFiles(fileio: self.application.fileio)
+                self.storage.files ?? NIOLeafFiles(fileio: self.application.fileio,
+                                                   limits: .default,
+                                                   sandboxDirectory: self.configuration.rootDirectory,
+                                                   viewDirectory: self.configuration.rootDirectory)
             }
             nonmutating set {
                 self.storage.files = newValue

--- a/Sources/Leaf/Application+Leaf.swift
+++ b/Sources/Leaf/Application+Leaf.swift
@@ -25,7 +25,7 @@ extension Application {
             return .init(
                 configuration: self.configuration,
                 cache: self.cache,
-                files: self.files,
+                sources: self.sources,
                 eventLoop: self.application.eventLoopGroup.next(),
                 userInfo: userInfo
             )
@@ -51,15 +51,16 @@ extension Application {
             }
         }
 
-        public var files: LeafSource {
+        public var sources: LeafSources {
             get {
-                self.storage.files ?? NIOLeafFiles(fileio: self.application.fileio,
-                                                   limits: .default,
-                                                   sandboxDirectory: self.configuration.rootDirectory,
-                                                   viewDirectory: self.configuration.rootDirectory)
+                self.storage.sources ?? LeafSources.singleSource(
+                                            NIOLeafFiles(fileio: self.application.fileio,
+                                                        limits: .default,
+                                                        sandboxDirectory: self.configuration.rootDirectory,
+                                                        viewDirectory: self.configuration.rootDirectory))
             }
             nonmutating set {
-                self.storage.files = newValue
+                self.storage.sources = newValue
             }
         }
 
@@ -98,7 +99,7 @@ extension Application {
         final class Storage {
             var cache: LeafCache
             var configuration: LeafConfiguration?
-            var files: LeafFiles?
+            var sources: LeafSources?
             var tags: [String: LeafTag]
             var userInfo: [AnyHashable: Any]
 

--- a/Sources/Leaf/Deprecated.swift
+++ b/Sources/Leaf/Deprecated.swift
@@ -1,0 +1,15 @@
+import Vapor
+
+
+extension Application.Leaf {
+    /// Deprecated in Leaf-Kit 1.0.0rc-1.??
+    @available(*, deprecated, message: "Use .sources instead of .files")
+    public var files: LeafSource {
+        get {
+            fatalError("Unavailable")
+        }
+        nonmutating set {
+            self.storage.sources = .singleSource(newValue)
+        }
+    }
+}

--- a/Sources/Leaf/Request+Leaf.swift
+++ b/Sources/Leaf/Request+Leaf.swift
@@ -10,7 +10,7 @@ extension Request {
             configuration: self.application.leaf.configuration,
             tags: self.application.leaf.tags,
             cache: self.application.leaf.cache,
-            files: self.application.leaf.files,
+            sources: self.application.leaf.sources,
             eventLoop: self.eventLoop,
             userInfo: userInfo
         )

--- a/Tests/LeafTests/LeafTests.swift
+++ b/Tests/LeafTests/LeafTests.swift
@@ -7,11 +7,11 @@ class LeafTests: XCTestCase {
         defer { app.shutdown() }
 
         app.views.use(.leaf)
-        app.leaf.configuration.rootDirectory = "/"
+        app.leaf.configuration.rootDirectory = projectFolder
         app.leaf.cache.isEnabled = false
 
         app.get("test-file") { req in
-            req.view.render(#file, ["foo": "bar"])
+            req.view.render("Tests/LeafTests/LeafTests.swift", ["foo": "bar"])
         }
 
         try app.test(.GET, "test-file") { res in


### PR DESCRIPTION
### LeafSources, LeafSource and File Sandboxing/Limiting in NIOLeafFiles ###

This update aligns Vapor+Leaf bindings to use LeafKit 1.0.0rc-1.11 API changes for sandboxing and file security behaviors, and using multiple sources for raw Leaf templates:

* `LeafSources` stores multiple `LeafSource`*-adhering objects by name and maintains a default search order of which objects to attempt to read from
* `LeafSource` (previously `LeafFiles`) represents any object with a directed behavior for interpreting a template name into its own reading space (eg, a filesystem or database)
* `NIOLeafFiles` gains initialization configuration for sandboxing and reading-limit behavior


For more details, please refer to the associated LeafKit update:
[LeafKit 1.0.0rc-1.11: LeafSources, LeafSource and File Sandboxing/Limiting in NIOLeafFiles](https://github.com/vapor/leaf-kit/tree/1.0.0-rc.1.11)

### BREAKING CHANGES FOR UNUSUAL USAGE CASES
If you are using a custom adherent to `LeafFiles`, you should update your object definition to conform to `LeafSource` and will no longer be able to access it via `app.leaf.files`. You will also need to expand "template" into a fully qualified file system path, if appropriate, internally - `LeafRenderer` will no longer directly expand the path before requesting it from a `LeafSource`

Adherents that wrapped NIOLeafFiles to use multiple directories may be better served by the new ability to have multiple `LeafSource` objects searched.

Please see above link to LeafKit 

### NOTES

* Default behavior for file access now limits all template references to prevent relative paths from escaping the configured ViewDirectory, and to block access to files without extensions, hidden files, or files in hidden directories.

* These behaviors can be configured by setting `Application.leaf.sources` to `LeafSources.singleSource(customNIOLeafFiles)` where the `NIOLeafFiles` initializer takes custom settings (for example, to allow absolute/relative paths to escape to a configured higher level directory, or to block access to any file NOT ending in `.leaf`), and allows setting the default directory to attempt to read from.

### Additional Changes ###
Updates Package.swift to require Vapor 4 release