### PR TITLE
LeafConfiguration Formatting Options

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "Leaf", targets: ["Leaf"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/vapor/leaf-kit.git", from: "1.0.0-rc.1.11"),
+        .package(url: "https://github.com/tdotclare/leaf-kit.git", .revision("ec30881caafab73bbb94a3a2e299dd67ef91bd8c")),
         .package(url: "https://github.com/vapor/vapor.git", from: "4.0.0"),
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "Leaf", targets: ["Leaf"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/tdotclare/leaf-kit.git", .revision("281084e6ede7ff42d8206010e75635aef2c89945")),
+        .package(url: "https://github.com/vapor/leaf-kit.git", from: "1.0.0-rc.1.16"),
         .package(url: "https://github.com/vapor/vapor.git", from: "4.0.0"),
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "Leaf", targets: ["Leaf"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/tdotclare/leaf-kit.git", .revision("ec30881caafab73bbb94a3a2e299dd67ef91bd8c")),
+        .package(url: "https://github.com/tdotclare/leaf-kit.git", .revision("281084e6ede7ff42d8206010e75635aef2c89945")),
         .package(url: "https://github.com/vapor/vapor.git", from: "4.0.0"),
     ],
     targets: [

--- a/Sources/Leaf/LeafEncoder.swift
+++ b/Sources/Leaf/LeafEncoder.swift
@@ -5,9 +5,7 @@ internal final class LeafEncoder {
         let encoder = _Encoder(codingPath: [])
         try encodable.encode(to: encoder)
         let data = encoder.container!.data!.resolve()
-        guard let dictionary = data.dictionary else {
-            fatalError()
-        }
+        guard let dictionary = data.dictionary else { fatalError() }
         return dictionary
     }
 }
@@ -34,9 +32,7 @@ enum _Data {
 
 /// Private `Encoder`.
 private final class _Encoder: Encoder {
-    var userInfo: [CodingUserInfoKey: Any] {
-        return [:]
-    }
+    var userInfo: [CodingUserInfoKey: Any] { [:] }
     let codingPath: [CodingKey]
     var container: _Container?
 
@@ -90,12 +86,8 @@ private final class SingleValueContainer: SingleValueEncodingContainer, _Contain
 
     /// See `SingleValueEncodingContainer`
     func encode<T>(_ value: T) throws where T: Encodable {
-        if let convertible = value as? LeafDataRepresentable {
-            if let converted = convertible.leafData {
-                self.data = .data(converted)
-            } else {
-                throw EncodingError.invalidValue(value, at: self.codingPath)
-            }
+        if let leafRepresentable = value as? LeafDataRepresentable {
+            self.data = .data(leafRepresentable.leafData)
         } else {
             let encoder = _Encoder(codingPath: self.codingPath)
             try value.encode(to: encoder)
@@ -131,11 +123,8 @@ private final class KeyedContainer<Key>: KeyedEncodingContainerProtocol, _Contai
     func encode<T>(_ value: T, forKey key: Key) throws
         where T : Encodable
     {
-        if let convertible = value as? LeafDataRepresentable {
-            guard let converted = convertible.leafData else {
-                throw EncodingError.invalidValue(value, at: self.codingPath + [key])
-            }
-            self.dictionary[key.stringValue] = .data(converted)
+        if let leafRepresentable = value as? LeafDataRepresentable {
+            self.dictionary[key.stringValue] = .data(leafRepresentable.leafData)
         } else {
             let encoder = _Encoder(codingPath: codingPath + [key])
             try value.encode(to: encoder)
@@ -191,11 +180,8 @@ private final class UnkeyedContainer: UnkeyedEncodingContainer, _Container {
 
     func encode<T>(_ value: T) throws where T: Encodable {
         defer { self.count += 1 }
-        if let convertible = value as? LeafDataRepresentable {
-            guard let converted = convertible.leafData else {
-                throw EncodingError.invalidValue(value, at: self.codingPath )
-            }
-            self.array.append(.data(converted))
+        if let leafRepresentable = value as? LeafDataRepresentable {
+            self.array.append(.data(leafRepresentable.leafData))
         } else {
             let encoder = _Encoder(codingPath: codingPath)
             try value.encode(to: encoder)

--- a/Tests/LeafTests/LeafTests.swift
+++ b/Tests/LeafTests/LeafTests.swift
@@ -5,10 +5,14 @@ class LeafTests: XCTestCase {
     func testApplication() throws {
         let app = Application(.testing)
         defer { app.shutdown() }
-
+        
         app.views.use(.leaf)
         app.leaf.configuration.rootDirectory = projectFolder
-        app.leaf.cache.isEnabled = false
+        app.leaf.sources = .singleSource(NIOLeafFiles(fileio: app.fileio,
+                                                      limits: .default,
+                                                      sandboxDirectory: projectFolder,
+                                                      viewDirectory: projectFolder))
+
 
         app.get("test-file") { req in
             req.view.render("Tests/LeafTests/LeafTests.swift", ["foo": "bar"])


### PR DESCRIPTION
This release exposes configuration methods for setting the default presentation output of data in rendered Leaf templates.

Static options are settable only until `app.leaf.renderer` is accessed or a `render(...)` call is made.

### Property Options

Stored property options in a `LeafConfiguration` may be used in various ways by a `LeafRenderer` which the configuration object was for, and changes to them after the object was provided to a specific `LeafRenderer` will have no affect.

```swift
.rootDirectory: String   // The default file directory used for file-system based `LeafSource`s                  
```

### Static Options

Static options on `LeafConfiguration` are effectively constant once any `LeafRenderer` has been instantiated and attempts to change them will assert in `Debug` and silently fail in `Release` to prevent inconsistent behavior.

```swift
 // The global tag indicator for LeafKit
.tagIndicator: Character == "#"
 // Encoding used when a template is serialized
.encoding: String.Encoding == .utf8

// Formatters for converting the base internal data types to Strings for serialization
.boolFormatter: (Bool) -> String = { $0.description }     // Bool.description
.intFormatter: (Int) -> String = { $0.description }       // Int.description
.doubleFormatter: (Double) -> String = { $0.description } // Double.description
.nilFormatter: () -> String = { "" }                      // Empty string (Optional containing .none)
.voidFormatter: () -> String = { "" }                     // Empty string (Tag with no return value)
.stringFormatter: (String) -> String = { $0 }             // Identity return
.dataFormatter: (Data) -> String? =
        { String(data: $0, encoding: Self._encoding) }    // Data using .encoding

// Note: Array & Dictionaries elements will already have been converted to Strings

.arrayFormatter: ([String]) -> String =                   // Array: [element, ..., element]
        { "[\($0.map {"\"\($0)\""}.joined(separator: ", "))]" }
.dictFormatter: ([String: String]) -> String =            // Dictionary: [key: value, ..., key: value]
        { "[\($0.map { "\($0): \"\($1)\"" }.joined(separator: ", "))]" }