### PR TITLE
Disable Leaf Cache for the Renderer in development

### DIFF
--- a/Sources/Leaf/Application+Leaf.swift
+++ b/Sources/Leaf/Application+Leaf.swift
@@ -23,10 +23,14 @@ extension Application {
             var userInfo = self.userInfo
             userInfo["application"] = self
 
+            var cache = self.cache
+            if self.application.environment == .development {
+                cache.isEnabled = false
+            }
             return .init(
                 configuration: self.configuration,
                 tags: self.tags,
-                cache: self.cache,
+                cache: cache,
                 sources: self.sources,
                 eventLoop: self.application.eventLoopGroup.next(),
                 userInfo: userInfo

--- a/Sources/Leaf/Application+Leaf.swift
+++ b/Sources/Leaf/Application+Leaf.swift
@@ -26,6 +26,8 @@ extension Application {
             var cache = self.cache
             if self.application.environment == .development {
                 cache.isEnabled = false
+            } else {
+                self.application.logger.notice("Starting Leaf Renderer with caching enabled")
             }
             return .init(
                 configuration: self.configuration,

--- a/Tests/LeafTests/LeafTests.swift
+++ b/Tests/LeafTests/LeafTests.swift
@@ -164,6 +164,24 @@ class LeafTests: XCTestCase {
             XCTAssertEqual(res.body.string, "Hello World! @ application")
         }
     }
+
+    func testLeafCacheDisabledInDevelopment() throws {
+        let app = Application(.development)
+        defer { app.shutdown() }
+
+        app.views.use(.leaf)
+
+        XCTAssertFalse(app.leaf.cache.isEnabled)
+    }
+
+    func testLeafCacheEnabledInProduction() throws {
+        let app = Application(.production)
+        defer { app.shutdown() }
+
+        app.views.use(.leaf)
+
+        XCTAssertTrue(app.leaf.cache.isEnabled)
+    }
 }
 
 /// Helper `LeafFiles` struct providing an in-memory thread-safe map of "file names" to "file data"

--- a/Tests/LeafTests/LeafTests.swift
+++ b/Tests/LeafTests/LeafTests.swift
@@ -171,7 +171,12 @@ class LeafTests: XCTestCase {
 
         app.views.use(.leaf)
 
-        XCTAssertFalse(app.leaf.cache.isEnabled)
+        guard let renderer = app.view as? LeafRenderer else {
+            XCTFail()
+            return
+        }
+
+        XCTAssertFalse(renderer.cache.isEnabled)
     }
 
     func testLeafCacheEnabledInProduction() throws {
@@ -180,7 +185,12 @@ class LeafTests: XCTestCase {
 
         app.views.use(.leaf)
 
-        XCTAssertTrue(app.leaf.cache.isEnabled)
+        guard let renderer = app.view as? LeafRenderer else {
+            XCTFail()
+            return
+        }
+
+        XCTAssertTrue(renderer.cache.isEnabled)
     }
 }
 


### PR DESCRIPTION
Disable the cache in Leaf's renderer when the environment is set to development.

Resolves #185 