### PR TITLE
Extend 'LeafRenderer' so that it can render 'Encodable' contexts

### DIFF
--- a/Sources/Leaf/LeafRenderer+ViewRenderer.swift
+++ b/Sources/Leaf/LeafRenderer+ViewRenderer.swift
@@ -9,14 +9,29 @@ extension LeafRenderer: ViewRenderer {
     public func render<E>(_ name: String, _ context: E) -> EventLoopFuture<View>
         where E: Encodable
     {
+        return self.render(path: name, context: context).map { buffer in
+            View(data: buffer)
+        }
+    }
+}
+
+extension LeafRenderer {
+    /// Populate the template at `path` with the data from `context`.
+    ///
+    /// - Parameters:
+    ///   - path: The name of the template to render.
+    ///   - context: Contextual data to render the template with.
+    /// - Returns: The serialized bytes of the rendered template.
+    public func render<Context>(path: String, context: Context) -> EventLoopFuture<ByteBuffer>
+        where Context: Encodable
+    {
         let data: [String: LeafData]
         do {
             data = try LeafEncoder().encode(context)
         } catch {
             return self.eventLoop.makeFailedFuture(error)
         }
-        return self.render(path: name, context: data).map { buffer in
-            return View(data: buffer)
-        }
+
+        return self.render(path: path, context: data)
     }
 }


### PR DESCRIPTION
Out of the box, the `LeafRenderer` offers a base API which can render
Leaf templates to a `ByteBuffer`. This requires the context to be provided
as a dictionary. With `ViewRenderer` conformance the `LeafRenderer` can
render `View`'s using an `Encodable` context.

However, there's no middle ground: the `LeafRenderer` can't render
templates to a `ByteBuffer` using an `Encodable` context. Since 
`LeafEncoder` is internal users can't make the extra hop from `Encodable`
context to dictionary to use the base API either. This functionality is helpful
when Leaf is used to render documents which aren't HTML.

As such this change adds an extension to `LeafRenderer` to render a
template to serialized bytes using an `Encodable` context.