### PR TITLE
Remove `fatalError()` when using array for `Context`

### DIFF
--- a/Sources/Leaf/LeafEncoder.swift
+++ b/Sources/Leaf/LeafEncoder.swift
@@ -7,7 +7,9 @@ internal final class LeafEncoder {
         let encoder = _Encoder(codingPath: [])
         try encodable.encode(to: encoder)
         let data = encoder.container!.data!.resolve()
-        guard let dictionary = data.dictionary else { fatalError() }
+        guard let dictionary = data.dictionary else {
+            throw LeafError(.unsupportedFeature("You must use a top level dictionary or type for the context. Arrays are not allowed"))
+        }
         return dictionary
     }
 }

--- a/Tests/LeafTests/LeafTests.swift
+++ b/Tests/LeafTests/LeafTests.swift
@@ -254,7 +254,8 @@ class LeafTests: XCTestCase {
         }
 
         try app.test(.GET, "noCrash") { res in
-            XCTAssertEqual(res.status, .ok)
+            // We used to fatal error
+            XCTAssertEqual(res.status, .internalServerError)
         }
     }
 }


### PR DESCRIPTION
Using arrays for top-level `Context`s in Leaf is not support. This changes the behaviour of Leaf to throw an error instead of `fatalError`ing and taking down the app.

Resolves #190 