### PR TITLE
Remove Starting Renderer with Caching Enabled Log

### DIFF
--- a/Sources/Leaf/Application+Leaf.swift
+++ b/Sources/Leaf/Application+Leaf.swift
@@ -26,8 +26,6 @@ extension Application {
             var cache = self.cache
             if self.application.environment == .development {
                 cache.isEnabled = false
-            } else {
-                self.application.logger.notice("Starting Leaf Renderer with caching enabled")
             }
             return .init(
                 configuration: self.configuration,


### PR DESCRIPTION
This removes the log message that states that the application is starting the Leaf Renderer with caching enabled. Because the `userInfo` is unique per request we can't cache the `renderer` so it needs to be created for each request (which is fine as everything else is stored in the request's storage). However this means that we get the log for each request.

Additionally the log might not be true if the application is configured to disable caching. Resolves #192 