### PR TITLE
Export `UnsafeUnescapedLeafTag`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "Leaf", targets: ["Leaf"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/vapor/leaf-kit.git", from: "1.3.0"),
+        .package(url: "https://github.com/vapor/leaf-kit.git", from: "1.3.1"),
         .package(url: "https://github.com/vapor/vapor.git", from: "4.0.0"),
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "Leaf", targets: ["Leaf"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/vapor/leaf-kit.git", from: "1.0.0"),
+        .package(url: "https://github.com/vapor/leaf-kit.git", from: "1.3.0"),
         .package(url: "https://github.com/vapor/vapor.git", from: "4.0.0"),
     ],
     targets: [

--- a/Sources/Leaf/Exports.swift
+++ b/Sources/Leaf/Exports.swift
@@ -1,4 +1,5 @@
 @_exported import protocol LeafKit.LeafTag
+@_exported import protocol LeafKit.UnsafeUnescapedLeafTag
 @_exported import struct LeafKit.LeafData
 @_exported import struct LeafKit.LeafContext
 @_exported import enum LeafKit.Syntax


### PR DESCRIPTION
Exports the new `UnsafeUnescapedLeafTag` so it's easy to use for anyone importing Leaf