### PR TITLE
Fix UnkeyedContainer crash for collections with nil

### DIFF
--- a/Sources/Leaf/LeafEncoder.swift
+++ b/Sources/Leaf/LeafEncoder.swift
@@ -189,7 +189,9 @@ private final class UnkeyedContainer: UnkeyedEncodingContainer, _Container {
         } else {
             let encoder = _Encoder(codingPath: codingPath)
             try value.encode(to: encoder)
-            self.array.append(encoder.container!.data!)
+            if let safeData = encoder.container!.data {
+                self.array.append(safeData)
+            }
         }
     }
 


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->
UnkeyedContainer throw fatal error in case of encoding collection with one or more nil values.
This change removes force unwrap of the input data and skip any nil value in a collection.

Resolves #197 

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
