### PR TITLE
Add experimental support for iOS

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,8 @@ import PackageDescription
 let package = Package(
     name: "leaf",
     platforms: [
-       .macOS(.v10_15)
+       .macOS(.v10_15),
+       .iOS(.v13)
     ],
     products: [
         .library(name: "Leaf", targets: ["Leaf"]),


### PR DESCRIPTION
This change allows Leaf to be used within iOS environments. Without it we get the following error:

`The package product 'Vapor' requires minimum platform version 13.0 for the iOS platform, but this target supports 9.0`