### PR TITLE
Fix reference cycle in LeafEncoder

### DIFF
--- a/Sources/Leaf/LeafEncoder.swift
+++ b/Sources/Leaf/LeafEncoder.swift
@@ -135,7 +135,7 @@ extension LeafEncoder {
     }
 
     private final class KeyedContainerImpl<Key>: KeyedEncodingContainerProtocol, LeafEncodingResolvable where Key: CodingKey {
-        private let encoder: EncoderImpl
+        private weak var encoder: EncoderImpl!
         private var data: [String: LeafEncodingResolvable] = [:]
         
         /// See ``LeafEncodingResolvable/resolvedData``.
@@ -196,7 +196,7 @@ extension LeafEncoder {
     }
     
     private final class UnkeyedContainerImpl: UnkeyedEncodingContainer, LeafEncodingResolvable {
-        private let encoder: EncoderImpl
+        private weak var encoder: EncoderImpl!
         private var data: [LeafEncodingResolvable] = []
         
         /// See ``LeafEncodingResolvable/resolvedData``.


### PR DESCRIPTION
This caused objects rendered in a view to be leaked, each time the view was rendered. This change breaks the reference cycle. A container should always be referenced by an encoder, so it should be safe to make the encoder reference weak, inside the container.

If anyone with more knowledge disagrees, please let me know what needs to change. Tested this in instruments, and it definitely fixes the cycle.