### PR TITLE
Fix retain cycle(s) in encoder implementation

### DIFF
--- a/Sources/Leaf/LeafEncoder.swift
+++ b/Sources/Leaf/LeafEncoder.swift
@@ -136,8 +136,9 @@ extension LeafEncoder {
     }
 
     private final class KeyedContainerImpl<Key>: KeyedEncodingContainerProtocol, LeafEncodingResolvable where Key: CodingKey {
-        private let encoder: EncoderImpl
+        private weak var encoder: EncoderImpl!
         private var data: [String: LeafEncodingResolvable] = [:]
+        private var nestedEncoderCaptures = [AnyObject]()
         
         /// See ``LeafEncodingResolvable/resolvedData``.
         var resolvedData: LeafData? { .dictionary(self.data.compactMapValues { $0.resolvedData }) }
@@ -158,10 +159,17 @@ extension LeafEncoder {
 
         /// See ``KeyedEncodingContainerProtocol/nestedContainer(keyedBy:forKey:)``.
         func nestedContainer<NestedKey: CodingKey>(keyedBy keyType: NestedKey.Type, forKey key: Key) -> KeyedEncodingContainer<NestedKey> {
+            guard let encoder = encoder else {
+                fatalError("Encoder deallocated")
+            }
+            
+            let nestedEncoder = EncoderImpl(from: encoder, withKey: key)
+            nestedEncoderCaptures.append(nestedEncoder)
+            
             /// Use a subencoder to create a nested container so the coding paths are correctly maintained.
             /// Save the subcontainer in our data so it can be resolved later before returning it.
-            .init(self.insert(
-                EncoderImpl(from: self.encoder, withKey: key).rawContainer(keyedBy: NestedKey.self),
+            return .init(self.insert(
+                nestedEncoder.rawContainer(keyedBy: NestedKey.self),
                 forKey: key,
                 as: KeyedContainerImpl<NestedKey>.self
             ))
@@ -169,8 +177,15 @@ extension LeafEncoder {
 
         /// See ``KeyedEncodingContainerProtocol/nestedUnkeyedContainer(forKey:)``.
         func nestedUnkeyedContainer(forKey key: Key) -> UnkeyedEncodingContainer {
-            self.insert(
-                EncoderImpl(from: self.encoder, withKey: key).unkeyedContainer() as! UnkeyedContainerImpl,
+            guard let encoder = encoder else {
+                fatalError("Encoder deallocated")
+            }
+            
+            let nestedEncoder = EncoderImpl(from: encoder, withKey: key)
+            nestedEncoderCaptures.append(nestedEncoder)
+            
+            return self.insert(
+                nestedEncoder.unkeyedContainer() as! UnkeyedContainerImpl,
                 forKey: key
             )
         }
@@ -178,15 +193,23 @@ extension LeafEncoder {
         /// A super encoder is, in fact, just a subdecoder with delusions of grandeur and some rather haughty
         /// pretensions. (It's mostly Codable's fault anyway.)
         func superEncoder() -> Encoder {
-            self.insert(
-                EncoderImpl(from: self.encoder, withKey: GenericCodingKey(stringValue: "super")),
+            guard let encoder = encoder else {
+                fatalError("Encoder deallocated")
+            }
+            
+            return self.insert(
+                EncoderImpl(from: encoder, withKey: GenericCodingKey(stringValue: "super")),
                 forKey: GenericCodingKey(stringValue: "super")
             )
         }
 
         /// See ``KeyedEncodingContainerProtocol/superEncoder(forKey:)``.
         func superEncoder(forKey key: Key) -> Encoder {
-            self.insert(EncoderImpl(from: self.encoder, withKey: key), forKey: key)
+            guard let encoder = encoder else {
+                fatalError("Encoder deallocated")
+            }
+            
+            return self.insert(EncoderImpl(from: encoder, withKey: key), forKey: key)
         }
 
         /// Helper for the encoding methods.
@@ -197,8 +220,10 @@ extension LeafEncoder {
     }
     
     private final class UnkeyedContainerImpl: UnkeyedEncodingContainer, LeafEncodingResolvable {
-        private let encoder: EncoderImpl
+        private weak var encoder: EncoderImpl!
         private var data: [LeafEncodingResolvable] = []
+        
+        private var nestedEncoderCaptures = [AnyObject]()
         
         /// See ``LeafEncodingResolvable/resolvedData``.
         var resolvedData: LeafData? { .array(data.compactMap(\.resolvedData)) }
@@ -224,20 +249,38 @@ extension LeafEncoder {
 
         /// See ``UnkeyedEncodingContainer/nestedContainer(keyedBy:)``.
         func nestedContainer<NestedKey: CodingKey>(keyedBy keyType: NestedKey.Type) -> KeyedEncodingContainer<NestedKey> {
-            .init(self.add(
-                EncoderImpl(from: self.encoder, withKey: self.nextCodingKey).rawContainer(keyedBy: NestedKey.self),
+            guard let encoder = encoder else {
+                fatalError("Encoder deallocated")
+            }
+            
+            let nestedEncoder = EncoderImpl(from: encoder, withKey: self.nextCodingKey)
+            nestedEncoderCaptures.append(nestedEncoder)
+            
+            return .init(self.add(
+                nestedEncoder.rawContainer(keyedBy: NestedKey.self),
                 as: KeyedContainerImpl<NestedKey>.self
             ))
         }
 
         /// See ``UnkeyedEncodingContainer/nestedUnkeyedContainer()``.
         func nestedUnkeyedContainer() -> UnkeyedEncodingContainer {
-            self.add(EncoderImpl(from: self.encoder, withKey: self.nextCodingKey).unkeyedContainer() as! UnkeyedContainerImpl)
+            guard let encoder = encoder else {
+                fatalError("Encoder deallocated")
+            }
+            
+            let nestedEncoder = EncoderImpl(from: encoder, withKey: self.nextCodingKey)
+            nestedEncoderCaptures.append(nestedEncoder)
+            
+            return self.add(nestedEncoder.unkeyedContainer() as! UnkeyedContainerImpl)
         }
 
         /// See ``UnkeyedEncodingContainer/superEncoder()``.
         func superEncoder() -> Encoder {
-            self.add(EncoderImpl(from: self.encoder, withKey: self.nextCodingKey))
+            guard let encoder = encoder else {
+                fatalError("Encoder deallocated")
+            }
+            
+            return self.add(EncoderImpl(from: encoder, withKey: self.nextCodingKey))
         }
 
         /// A `CodingKey` corresponding to the index that will be given to the next value added to the array.

--- a/Sources/Leaf/LeafEncoder.swift
+++ b/Sources/Leaf/LeafEncoder.swift
@@ -220,7 +220,7 @@ extension LeafEncoder {
     }
     
     private final class UnkeyedContainerImpl: UnkeyedEncodingContainer, LeafEncodingResolvable {
-        private weak var encoder: EncoderImpl?
+        private weak var encoder: EncoderImpl!
         private var data: [LeafEncodingResolvable] = []
         
         private var nestedEncoderCaptures = [AnyObject]()

--- a/Sources/Leaf/LeafEncoder.swift
+++ b/Sources/Leaf/LeafEncoder.swift
@@ -136,7 +136,7 @@ extension LeafEncoder {
     }
 
     private final class KeyedContainerImpl<Key>: KeyedEncodingContainerProtocol, LeafEncodingResolvable where Key: CodingKey {
-        private weak var encoder: EncoderImpl?
+        private weak var encoder: EncoderImpl!
         private var data: [String: LeafEncodingResolvable] = [:]
         private var nestedEncoderCaptures = [AnyObject]()
         

--- a/Sources/Leaf/LeafEncoder.swift
+++ b/Sources/Leaf/LeafEncoder.swift
@@ -136,7 +136,7 @@ extension LeafEncoder {
     }
 
     private final class KeyedContainerImpl<Key>: KeyedEncodingContainerProtocol, LeafEncodingResolvable where Key: CodingKey {
-        private weak var encoder: EncoderImpl!
+        private weak var encoder: EncoderImpl?
         private var data: [String: LeafEncodingResolvable] = [:]
         private var nestedEncoderCaptures = [AnyObject]()
         

--- a/Sources/Leaf/LeafEncoder.swift
+++ b/Sources/Leaf/LeafEncoder.swift
@@ -220,7 +220,7 @@ extension LeafEncoder {
     }
     
     private final class UnkeyedContainerImpl: UnkeyedEncodingContainer, LeafEncodingResolvable {
-        private weak var encoder: EncoderImpl!
+        private weak var encoder: EncoderImpl?
         private var data: [LeafEncodingResolvable] = []
         
         private var nestedEncoderCaptures = [AnyObject]()


### PR DESCRIPTION
This PR addresses issue https://github.com/vapor/leaf/issues/215 and server as an alternative of PR https://github.com/vapor/leaf/pull/216, that somehow got stuck in it's efforts of being merged in.

I've done 2 things to discover the issue and confirm the fix
- Xcode would show a bunch of memory leaks when using it's memory graph debugger, those are gone after the changes introduced in this PR
- I've switched https://swiftpack.co, which uses leaf heavily, to using my fork with this fix. The heroku graph bellow shows significantly lower memory consumption and does not seem to be crashing, though I still do do seem to have memory leaks somewhere in the codebase.

<img width="1223" alt="Screenshot 2022-10-11 at 8 09 09" src="https://user-images.githubusercontent.com/1067678/196025866-b2610ab8-de21-4dba-9add-87b30b2919d6.png">
<img width="1512" alt="Screenshot 2022-10-09 at 18 38 05" src="https://user-images.githubusercontent.com/1067678/196025908-ac231a1f-a87e-4955-9119-e5c94f76403d.png">
<img width="1512" alt="Screenshot 2022-10-09 at 18 35 00" src="https://user-images.githubusercontent.com/1067678/196025912-40c8fe04-0fae-4c71-bf53-602339af9921.png">
<img width="1512" alt="Screenshot 2022-10-09 at 18 36 58" src="https://user-images.githubusercontent.com/1067678/196025915-8ca9b7b3-3b76-42ba-9bf3-8bc0d01a97be.png">
<img width="1512" alt="Screenshot 2022-10-09 at 18 32 46" src="https://user-images.githubusercontent.com/1067678/196025916-58676f06-210c-48eb-b66c-079817cd9df0.png">
<img width="1512" alt="Screenshot 2022-10-09 at 18 35 33" src="https://user-images.githubusercontent.com/1067678/196025917-20870599-1853-4532-96aa-ced9b8a81588.png">
