### PR TITLE
Fix retain cycle(s) in encoder implementation without adding any fatalError()

### DIFF
--- a/Sources/Leaf/LeafEncoder.swift
+++ b/Sources/Leaf/LeafEncoder.swift
@@ -7,7 +7,7 @@ internal struct LeafEncoder {
     /// top level; it may not be an array or scalar value.
     static func encode<E>(_ encodable: E) throws -> [String: LeafData] where E: Encodable {
         let encoder = EncoderImpl(codingPath: [])
-        try encodable.encode(to: encoder)
+        try encoder.encode(encodable)
         
         // If the context encoded nothing at all, yield an empty dictionary.
         let data = encoder.storage?.resolvedData ?? .dictionary([:])


### PR DESCRIPTION
This PR addresses the issue #215 and serves as an alternative to #220 without adding any fatalError().

In order to confirm the fix, I have added debug output to the deinit method of EncoderImpl.

Running the test cases it clearly shows that when encoding via `try encoder.encode(encodable)` the deinit gets called on every test case, whereas with the old `try encodable.encode(to: encoder)` that is not the case.

The nested EncoderImpl are referenced weakly in a similar way as proposed in #220 in order to break retain cycles. However, instead of adding `fatalError()` calls when the EncoderImpl is deallocated, an error will be thrown.