### PR TITLE
Fix Algorithms Dependency Declaration

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,6 +14,7 @@ let package = Package(
         .package(url: "https://github.com/vapor/leaf-kit.git", from: "1.3.1"),
         
         .package(url: "https://github.com/vapor/vapor.git", from: "4.0.0"),
+        
         // Swift collection algorithms
         .package(url: "https://github.com/apple/swift-algorithms.git", from: "1.0.0"),
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -12,11 +12,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/vapor/leaf-kit.git", from: "1.3.1"),
-        
         .package(url: "https://github.com/vapor/vapor.git", from: "4.0.0"),
-        
-        // Swift collection algorithms
-        .package(url: "https://github.com/apple/swift-algorithms.git", from: "1.0.0"),
     ],
     targets: [
         .target(name: "Leaf", dependencies: [

--- a/Package.swift
+++ b/Package.swift
@@ -12,12 +12,16 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/vapor/leaf-kit.git", from: "1.3.1"),
+        
         .package(url: "https://github.com/vapor/vapor.git", from: "4.0.0"),
+        // Swift collection algorithms
+        .package(url: "https://github.com/apple/swift-algorithms.git", from: "1.0.0"),
     ],
     targets: [
         .target(name: "Leaf", dependencies: [
             .product(name: "LeafKit", package: "leaf-kit"),
             .product(name: "Vapor", package: "vapor"),
+            .product(name: "Algorithms", package: "swift-algorithms")
         ]),
         .testTarget(name: "LeafTests", dependencies: [
             .target(name: "Leaf"),

--- a/Sources/Leaf/LeafEncoder.swift
+++ b/Sources/Leaf/LeafEncoder.swift
@@ -1,4 +1,5 @@
 import LeafKit
+import Algorithms
 
 internal struct LeafEncoder {
     /// Use `Codable` to convert an (almost) arbitrary encodable type to a dictionary of key/``LeafData`` pairs

--- a/Sources/Leaf/LeafEncoder.swift
+++ b/Sources/Leaf/LeafEncoder.swift
@@ -79,7 +79,7 @@ extension LeafEncoder {
         }
         
         convenience init(from encoder: EncoderImpl, withKey key: CodingKey?) {
-            self.init(userInfo: encoder.userInfo, codingPath: encoder.codingPath + [key].compactMap { $0 })
+            self.init(userInfo: encoder.userInfo, codingPath: encoder.codingPath + [key].compacted())
         }
         
         /// Need to expose the ability to access unwrapped keyed container to enable use of nested

--- a/Sources/Leaf/LeafEncoder.swift
+++ b/Sources/Leaf/LeafEncoder.swift
@@ -1,5 +1,4 @@
 import LeafKit
-import Algorithms
 
 internal struct LeafEncoder {
     /// Use `Codable` to convert an (almost) arbitrary encodable type to a dictionary of key/``LeafData`` pairs
@@ -79,7 +78,7 @@ extension LeafEncoder {
         }
         
         convenience init(from encoder: EncoderImpl, withKey key: CodingKey?) {
-            self.init(userInfo: encoder.userInfo, codingPath: encoder.codingPath + [key].compacted())
+            self.init(userInfo: encoder.userInfo, codingPath: encoder.codingPath + [key].compactMap { $0 })
         }
         
         /// Need to expose the ability to access unwrapped keyed container to enable use of nested


### PR DESCRIPTION
Swift Algorithms was used in Leaf but never explicitly declared as a dependency on the target. That resulted in compiler errors in some scenarios. The dependency is now correctly declared.