### PR TITLE
Fix Exports.swift

### DIFF
--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -11,4 +11,4 @@ jobs:
      with:
        package_name: leaf
        modules: Leaf
-       pathsToInvalidate: /leaf
+       pathsToInvalidate: /leaf/*

--- a/.github/workflows/projectboard.yml
+++ b/.github/workflows/projectboard.yml
@@ -7,5 +7,5 @@ on:
 jobs:
   update_project_boards:
     name: Update project boards
-    uses: vapor/ci/.github/workflows/update-project-boards-for-issue.yml@reusable-workflows
+    uses: vapor/ci/.github/workflows/update-project-boards-for-issue.yml@main
     secrets: inherit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,11 @@
 name: test
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 on:
-- pull_request
+  pull_request: { types: [opened, reopened, synchronize, ready_for_review] }
+  push: { branches: [ main ] }
+
 jobs:
   unit-tests:
-     uses: vapor/ci/.github/workflows/run-unit-tests.yml@reusable-workflows
-     with:
-       with_coverage: false
-       with_tsan: true
-       with_public_api_check: true
+     uses: vapor/ci/.github/workflows/run-unit-tests.yml@main

--- a/Package.swift
+++ b/Package.swift
@@ -1,21 +1,20 @@
-// swift-tools-version:5.4
+// swift-tools-version:5.6
 import PackageDescription
 
 let package = Package(
     name: "leaf",
     platforms: [
-       .macOS(.v10_15),
-       .iOS(.v13)
+        .macOS(.v10_15),
+        .iOS(.v13),
+        .tvOS(.v13),
+        .watchOS(.v6)
     ],
     products: [
         .library(name: "Leaf", targets: ["Leaf"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/vapor/leaf-kit.git", from: "1.3.1"),
-        
+        .package(url: "https://github.com/vapor/leaf-kit.git", from: "1.3.1"),        
         .package(url: "https://github.com/vapor/vapor.git", from: "4.0.0"),
-        
-        // Swift collection algorithms
         .package(url: "https://github.com/apple/swift-algorithms.git", from: "1.0.0"),
     ],
     targets: [

--- a/README.md
+++ b/README.md
@@ -1,24 +1,15 @@
 <p align="center">
-    <img 
-        src="https://user-images.githubusercontent.com/1342803/75696046-ee2d5280-5c78-11ea-8201-38f109c3a0eb.png" 
-        height="64" 
-        alt="Leaf"
-    >
-    <br>
-    <br>
-    <a href="https://docs.vapor.codes/4.0/">
-        <img src="http://img.shields.io/badge/read_the-docs-2196f3.svg" alt="Documentation">
-    </a>
-    <a href="https://discord.gg/vapor">
-        <img src="https://img.shields.io/discord/431917998102675485.svg" alt="Team Chat">
-    </a>
-    <a href="LICENSE">
-        <img src="http://img.shields.io/badge/license-MIT-brightgreen.svg" alt="MIT License">
-    </a>
-    <a href="https://github.com/vapor/leaf/actions">
-        <img src="https://github.com/vapor/leaf/workflows/test/badge.svg" alt="Continuous Integration">
-    </a>
-    <a href="https://swift.org">
-        <img src="http://img.shields.io/badge/swift-5.2-brightgreen.svg" alt="Swift 5.2">
-    </a>
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://user-images.githubusercontent.com/1130717/259964919-5afdacc0-310d-408b-9d83-9018b92d96e0.png">
+  <source media="(prefers-color-scheme: light)" srcset="https://user-images.githubusercontent.com/1130717/259964940-b450247b-8110-4757-870f-eda1a34b2e81.png">
+  <img src="https://user-images.githubusercontent.com/1130717/259964940-b450247b-8110-4757-870f-eda1a34b2e81.png" height="96" alt="Leaf">
+</picture>
+<br>
+<br>
+<a href="https://docs.vapor.codes/4.0/"><img src="https://img.shields.io/badge/read_the-docs-2196f3.svg" alt="Documentation"></a>
+<a href="https://discord.gg/vapor"><img src="https://img.shields.io/discord/431917998102675485.svg" alt="Team Chat"></a>
+<a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-brightgreen.svg" alt="MIT License"></a>
+<a href="https://github.com/vapor/leaf/actions/workflows/test.yml"><img src="https://github.com/vapor/leaf/actions/workflows/test.yml/badge.svg" alt="Continuous Integration"></a>
+<a href="https://swift.org"><img src="https://img.shields.io/badge/swift-5.6-brightgreen.svg" alt="Swift 5.6"></a>
 </p>
+<br>

--- a/Sources/Leaf/Exports.swift
+++ b/Sources/Leaf/Exports.swift
@@ -1,4 +1,12 @@
-#if !BUILDING_DOCC
+#if swift(>=5.8)
+
+@_documentation(visibility: internal) @_exported import protocol LeafKit.LeafTag
+@_documentation(visibility: internal) @_exported import protocol LeafKit.UnsafeUnescapedLeafTag
+@_documentation(visibility: internal) @_exported import struct LeafKit.LeafData
+@_documentation(visibility: internal) @_exported import struct LeafKit.LeafContext
+@_documentation(visibility: internal) @_exported import enum LeafKit.Syntax
+
+#else
 
 @_exported import protocol LeafKit.LeafTag
 @_exported import protocol LeafKit.UnsafeUnescapedLeafTag


### PR DESCRIPTION
This officially cleans up the last repo left that still has an uncorrected `Exports.swift`. Cleans up the README and CI workflows too.