### PR TITLE
Bump Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.6
+// swift-tools-version:5.7
 import PackageDescription
 
 let package = Package(
@@ -13,9 +13,9 @@ let package = Package(
         .library(name: "Leaf", targets: ["Leaf"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/vapor/leaf-kit.git", from: "1.10.2"),        
-        .package(url: "https://github.com/vapor/vapor.git", from: "4.78.1"),
-        .package(url: "https://github.com/apple/swift-algorithms.git", from: "1.0.0"),
+        .package(url: "https://github.com/vapor/leaf-kit.git", from: "1.10.3"),        
+        .package(url: "https://github.com/vapor/vapor.git", from: "4.92.1"),
+        .package(url: "https://github.com/apple/swift-algorithms.git", from: "1.2.0"),
     ],
     targets: [
         .target(name: "Leaf", dependencies: [

--- a/README.md
+++ b/README.md
@@ -3,13 +3,15 @@
   <source media="(prefers-color-scheme: dark)" srcset="https://user-images.githubusercontent.com/1130717/259964919-5afdacc0-310d-408b-9d83-9018b92d96e0.png">
   <source media="(prefers-color-scheme: light)" srcset="https://user-images.githubusercontent.com/1130717/259964940-b450247b-8110-4757-870f-eda1a34b2e81.png">
   <img src="https://user-images.githubusercontent.com/1130717/259964940-b450247b-8110-4757-870f-eda1a34b2e81.png" height="96" alt="Leaf">
-</picture>
+</picture> 
 <br>
 <br>
-<a href="https://docs.vapor.codes/4.0/"><img src="https://img.shields.io/badge/read_the-docs-2196f3.svg" alt="Documentation"></a>
-<a href="https://discord.gg/vapor"><img src="https://img.shields.io/discord/431917998102675485.svg" alt="Team Chat"></a>
-<a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-brightgreen.svg" alt="MIT License"></a>
-<a href="https://github.com/vapor/leaf/actions/workflows/test.yml"><img src="https://github.com/vapor/leaf/actions/workflows/test.yml/badge.svg" alt="Continuous Integration"></a>
-<a href="https://swift.org"><img src="https://img.shields.io/badge/swift-5.6-brightgreen.svg" alt="Swift 5.6"></a>
+<a href="https://docs.vapor.codes/4.0/"><img src="https://design.vapor.codes/images/readthedocs.svg" alt="Documentation"></a>
+<a href="https://discord.gg/vapor"><img src="https://design.vapor.codes/images/discordchat.svg" alt="Team Chat"></a>
+<a href="LICENSE"><img src="https://design.vapor.codes/images/mitlicense.svg" alt="MIT License"></a>
+<a href="https://github.com/vapor/leaf/actions/workflows/test.yml"><img src="https://img.shields.io/github/actions/workflow/status/vapor/leaf/test.yml?event=push&style=plastic&logo=github&label=tests&logoColor=%23ccc" alt="Continuous Integration"></a>
+<a href="https://codecov.io/github/vapor/leaf"><img src="https://img.shields.io/codecov/c/github/vapor/leaf?style=plastic&logo=codecov&label=codecov"></a>
+<a href="https://swift.org"><img src="https://design.vapor.codes/images/swift57up.svg" alt="Swift 5.7+"></a>
 </p>
+
 <br>


### PR DESCRIPTION
This package should have gotten a release after the previous update to its `Package.swift`, but it was overlooked. This one further updates the versions and should resolve version issues with the Leaf provider.