### PR TITLE
Fix `LeafContext.application` Casting Failure

### DIFF
--- a/Sources/Leaf/Application+Leaf.swift
+++ b/Sources/Leaf/Application+Leaf.swift
@@ -21,7 +21,7 @@ extension Application {
 
         public var renderer: LeafRenderer {
             var userInfo = self.userInfo
-            userInfo["application"] = self
+            userInfo["application"] = self.application
 
             var cache = self.cache
             if self.application.environment == .development {


### PR DESCRIPTION
Fixes an issue where the wrong type would be set to the `application` `userInfo` key when accessing the renderer directly on the `Application` (it would set a value of `Application.Leaf`, rather than `Application`, and then the casting would fail on `LeafContext.application`).