### PR TITLE
Refactor encoder property to weak reference in KeyedContainerImpl and UnkeyedContainerImpl to prevent retain cycles

### DIFF
--- a/Tests/LeafTests/LeafMemoryGrowthTests.swift
+++ b/Tests/LeafTests/LeafMemoryGrowthTests.swift
@@ -8,7 +8,7 @@ import XCTVapor
  ```bash
  #!/bin/zsh
  swift test --filter LeafMemoryGrowthTests &
- sleep 3
+ sleep 5
  PID=$(ps aux | grep '[l]eafPackageTests' | awk '{print $2}' | head -n1)
  echo "leafPackageTests PID: $PID"
  leaks $PID

--- a/Tests/LeafTests/LeafMemoryGrowthTests.swift
+++ b/Tests/LeafTests/LeafMemoryGrowthTests.swift
@@ -15,36 +15,36 @@ import XCTVapor
  ```
 */
 final class LeafMemoryGrowthTests: XCTestCase {
-    func testRepeatedRenderMemoryGrowth() async throws {
-        sleep(3) // Keep process alive for leaks profiling
-        var test = TestFiles()
-        test.files["/foo.leaf"] = "Hello #(name)!"
-        
-        try await withApp { app in
-            app.views.use(.leaf)
-            app.leaf.sources = .singleSource(test)
-            struct Foo: Encodable { var name: String }
-            // Render with context 1000 times
-            for _ in 0..<1000 {
-                _ = try await app.leaf.renderer.render(path: "foo", context: Foo(name: "World")).get()
-            }
-        }
-        sleep(10) // Keep process alive for leaks profiling
-    }
-    
-    func testRepeatedRenderNoContextMemoryGrowth() async throws {
-        sleep(3) // Keep process alive for leaks profiling
-        var test = TestFiles()
-        test.files["/foo.leaf"] = "Hello!"
-        
-        try await withApp { app in
-            app.views.use(.leaf)
-            app.leaf.sources = .singleSource(test)
-            // Render without context 1000 times (pass nil context)
-            for _ in 0..<1000 {
-                _ = try await app.leaf.renderer.render(path: "foo", context: Optional<Bool>.none).get()
-            }
-        }
-        sleep(10) // Keep process alive for leaks profiling
-    }
+//    func testRepeatedRenderMemoryGrowth() async throws {
+//        sleep(3) // Keep process alive for leaks profiling
+//        var test = TestFiles()
+//        test.files["/foo.leaf"] = "Hello #(name)!"
+//        
+//        try await withApp { app in
+//            app.views.use(.leaf)
+//            app.leaf.sources = .singleSource(test)
+//            struct Foo: Encodable { var name: String }
+//            // Render with context 1000 times
+//            for _ in 0..<1000 {
+//                _ = try await app.leaf.renderer.render(path: "foo", context: Foo(name: "World")).get()
+//            }
+//        }
+//        sleep(10) // Keep process alive for leaks profiling
+//    }
+//    
+//    func testRepeatedRenderNoContextMemoryGrowth() async throws {
+//        sleep(3) // Keep process alive for leaks profiling
+//        var test = TestFiles()
+//        test.files["/foo.leaf"] = "Hello!"
+//        
+//        try await withApp { app in
+//            app.views.use(.leaf)
+//            app.leaf.sources = .singleSource(test)
+//            // Render without context 1000 times (pass nil context)
+//            for _ in 0..<1000 {
+//                _ = try await app.leaf.renderer.render(path: "foo", context: Optional<Bool>.none).get()
+//            }
+//        }
+//        sleep(10) // Keep process alive for leaks profiling
+//    }
 }

--- a/Tests/LeafTests/LeafMemoryGrowthTests.swift
+++ b/Tests/LeafTests/LeafMemoryGrowthTests.swift
@@ -1,0 +1,50 @@
+import XCTest
+import Leaf
+import LeafKit
+import XCTVapor
+
+/*
+ to profile memory growth, use an sh script like this:
+ ```bash
+ #!/bin/zsh
+ swift test --filter LeafMemoryGrowthTests &
+ sleep 3
+ PID=$(ps aux | grep '[l]eafPackageTests' | awk '{print $2}' | head -n1)
+ echo "leafPackageTests PID: $PID"
+ leaks $PID
+ ```
+*/
+final class LeafMemoryGrowthTests: XCTestCase {
+    func testRepeatedRenderMemoryGrowth() async throws {
+        sleep(3) // Keep process alive for leaks profiling
+        var test = TestFiles()
+        test.files["/foo.leaf"] = "Hello #(name)!"
+        
+        try await withApp { app in
+            app.views.use(.leaf)
+            app.leaf.sources = .singleSource(test)
+            struct Foo: Encodable { var name: String }
+            // Render with context 1000 times
+            for _ in 0..<1000 {
+                _ = try await app.leaf.renderer.render(path: "foo", context: Foo(name: "World")).get()
+            }
+        }
+        sleep(10) // Keep process alive for leaks profiling
+    }
+    
+    func testRepeatedRenderNoContextMemoryGrowth() async throws {
+        sleep(3) // Keep process alive for leaks profiling
+        var test = TestFiles()
+        test.files["/foo.leaf"] = "Hello!"
+        
+        try await withApp { app in
+            app.views.use(.leaf)
+            app.leaf.sources = .singleSource(test)
+            // Render without context 1000 times (pass nil context)
+            for _ in 0..<1000 {
+                _ = try await app.leaf.renderer.render(path: "foo", context: Optional<Bool>.none).get()
+            }
+        }
+        sleep(10) // Keep process alive for leaks profiling
+    }
+}


### PR DESCRIPTION
I've noticed memory usage growth in my project that is described in https://github.com/vapor/leaf/issues/238 

After adding some tests and running `leaks`, I found that currently there are retain cycles. That PR fixes them.

That's what `leaks` printed (a lot of similar messages):
```bash

  4 (352 bytes) ROOT CYCLE: <EncoderImpl 0x1572270d0> [80]
     3 (272 bytes) storage --> ROOT CYCLE: <Leaf.LeafEncoder.(KeyedContainerImpl in _30C79F4310B915184892E56903FC555A)<CodingKeys in Foo #1 in closure #1 (Vapor.Application) async throws -> () in LeafTests.LeafMemoryGrowthTests.testRepeatedRenderMemoryGrowth() async throws -> ()> 0x157227120> [48]
        __strong encoder --> CYCLE BACK TO <EncoderImpl 0x1572270d0> [80]
        2 (224 bytes) __strong data._variant --> <Swift._DictionaryStorage<Swift.String, Leaf.(LeafEncodingResolvable in _30C79F4310B915184892E56903FC555A)> 0x157227170> [192]  item count: 1
           1 (32 bytes) <Closure context 0x157227150> [32]

  2 (128 bytes) ROOT CYCLE: <EncoderImpl 0x156710ad0> [80]
     1 (48 bytes) storage --> ROOT CYCLE: <Leaf.LeafEncoder.(KeyedContainerImpl in _30C79F4310B915184892E56903FC555A)<CodingKeys in Foo #1 in closure #1 (Vapor.Application) async throws -> () in LeafTests.LeafMemoryGrowthTests.testRepeatedRenderMemoryGrowth() async throws -> ()> 0x156710b20> [48]
        __strong encoder --> CYCLE BACK TO <EncoderImpl 0x156710ad0> [80]

```